### PR TITLE
feat: `useListNavigation` and base tree view

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-undef
 module.exports = {
   testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['@testing-library/jest-dom'],
   testMatch: ['**/?(*.)+(test).+(ts|tsx|js)'],
 };

--- a/src/components/content/tree-view/TreeView.tsx
+++ b/src/components/content/tree-view/TreeView.tsx
@@ -1,0 +1,182 @@
+import { composeEventHandlers } from '@radix-ui/primitive';
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
+import {
+  Children,
+  forwardRef,
+  HTMLAttributes,
+  isValidElement,
+  ReactNode,
+  useCallback,
+  useRef,
+} from 'react';
+import { useControllableState } from '@radix-ui/react-use-controllable-state';
+import { Primitive } from '@radix-ui/react-primitive';
+
+import useListNavigation from '../../../hooks/useListNavigation';
+import { styled } from '../../../../stitches.config';
+import { createContext } from '../../utility/createContext';
+// import { FocusScope } from 'react-aria';
+
+interface TreeViewContextValue {
+  selectedElement: Element | undefined;
+}
+const [TreeViewProvider, useTreeViewContext] =
+  createContext<TreeViewContextValue>('TreeView');
+
+type RootProps = HTMLAttributes<HTMLUListElement>;
+const Root = forwardRef<HTMLUListElement, RootProps>((props, ref) => {
+  const listRef = useRef<HTMLUListElement>(null);
+  const composedRefs = useComposedRefs(ref, listRef);
+  const [selectedElement, { handleKeyDown }] = useListNavigation({
+    listRef,
+    itemSelector: '[craft-tree-item=""]',
+  });
+
+  return (
+    <TreeViewProvider selectedElement={selectedElement}>
+      <ul
+        ref={composedRefs}
+        {...props}
+        role="tree"
+        // eslint-disable-next-line react/no-unknown-property
+        craft-tree-root=""
+        tabIndex={0}
+        onKeyDown={composeEventHandlers(
+          props.onKeyDown,
+          event => {
+            handleKeyDown(event);
+          },
+          {
+            checkForDefaultPrevented: true,
+          }
+        )}
+      >
+        <input />
+        {props.children}
+      </ul>
+    </TreeViewProvider>
+  );
+});
+
+interface ItemContextValue {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+const [ItemProvider, useItemContext] =
+  createContext<ItemContextValue>('Tree.Item');
+interface ItemProps extends HTMLAttributes<HTMLLIElement> {
+  value: string;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+// TODO: level?
+const Item = forwardRef<HTMLLIElement, ItemProps>((props, ref) => {
+  const {
+    value,
+    open: openFromProps,
+    defaultOpen,
+    onOpenChange,
+    ...restProps
+  } = props;
+
+  const { selectedElement } = useTreeViewContext('Tree.Item');
+  const [open = false, setOpen] = useControllableState({
+    prop: openFromProps,
+    defaultProp: defaultOpen,
+    onChange: onOpenChange,
+  });
+
+  const listItemRef = useRef<HTMLLIElement>(null);
+  const composedRefs = useComposedRefs(ref, listItemRef);
+  const selected = listItemRef.current === selectedElement;
+  const hasSubTree = getSubTree(props.children) != null;
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      // https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
+      switch (event.key) {
+        case 'ArrowRight':
+          // event.preventDefault();
+          // event.stopPropagation();
+          setOpen(true);
+          break;
+        case 'ArrowLeft':
+          // event.preventDefault();
+          // event.stopPropagation();
+          setOpen(false);
+          break;
+      }
+    },
+    [setOpen]
+  );
+
+  return (
+    <ItemProvider open={open} onOpenChange={setOpen}>
+      {/* eslint-disable-next-line react/no-unknown-property */}
+      <Li
+        ref={composedRefs}
+        {...restProps}
+        tabIndex={0}
+        role="treeitem"
+        craft-tree-item=""
+        onKeyDown={handleKeyDown}
+        aria-selected={selected || undefined}
+        aria-expanded={!hasSubTree ? undefined : open}
+      >
+        {props.children}
+      </Li>
+    </ItemProvider>
+  );
+});
+
+interface OpenControlProps
+  extends Omit<HTMLAttributes<HTMLButtonElement>, 'children'> {
+  children: (params: { open: boolean }) => ReactNode;
+}
+const OpenControl = forwardRef<HTMLButtonElement, OpenControlProps>(
+  (props, ref) => {
+    const { onOpenChange, open } = useItemContext('Tree.OpenControl');
+    const { children, ...restProps } = props;
+
+    return (
+      <Primitive.button
+        asChild
+        ref={ref}
+        {...restProps}
+        onClick={composeEventHandlers(props.onClick, () => {
+          onOpenChange(!open);
+        })}
+      >
+        {children({ open })}
+      </Primitive.button>
+    );
+  }
+);
+
+const SubTree = forwardRef<HTMLOListElement, HTMLAttributes<HTMLOListElement>>(
+  (props, ref) => {
+    const { open } = useItemContext('Tree.SubTree');
+    return open ? <ol ref={ref} {...props} /> : null;
+  }
+);
+
+function getSubTree(children: ReactNode) {
+  return Children.toArray(children).find(
+    child => isValidElement(child) && child.type === SubTree
+  );
+}
+
+const Li = styled('li', {
+  '&[aria-selected="true"]': {
+    color: 'red',
+  },
+});
+const Tree = Object.assign(Root, {
+  Item,
+  SubTree,
+  OpenControl,
+});
+
+export default Tree;

--- a/src/hooks/useListNavigation.test.tsx
+++ b/src/hooks/useListNavigation.test.tsx
@@ -1,0 +1,141 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { render, fireEvent } from '@testing-library/react';
+import { useRef } from 'react';
+
+import useListNavigation from './useListNavigation';
+
+const ITEMS = ['one', 'two', 'three'];
+function BasicExample(props: { loop?: boolean; itemSelector?: string }) {
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const [selectedElement, { handleKeyDown }] = useListNavigation({
+    listRef,
+    ...props,
+  });
+
+  return (
+    <ul
+      ref={listRef}
+      tabIndex={0}
+      aria-activedescendant={selectedElement?.id}
+      onKeyDown={handleKeyDown}
+    >
+      <li id={ITEMS[0]}>{ITEMS[0]}</li>
+      <li id={ITEMS[1]}>{ITEMS[1]}</li>
+      <li id={ITEMS[2]}>{ITEMS[2]}</li>
+    </ul>
+  );
+}
+
+function InputExample(props: { loop?: boolean; itemSelector?: string }) {
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const [selectedElement, { handleKeyDown }] = useListNavigation({
+    listRef,
+    ...props,
+  });
+
+  return (
+    <div tabIndex={0} onKeyDown={handleKeyDown}>
+      <input />
+      <ul ref={listRef} aria-activedescendant={selectedElement?.id}>
+        <li id={ITEMS[0]}>{ITEMS[0]}</li>
+        <li id={ITEMS[1]}>{ITEMS[1]}</li>
+        <li id={ITEMS[2]}>{ITEMS[2]}</li>
+      </ul>
+    </div>
+  );
+}
+
+function InvalidItemExample() {
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const [selectedElement, { handleKeyDown }] = useListNavigation({
+    listRef,
+  });
+
+  return (
+    <ul
+      ref={listRef}
+      tabIndex={0}
+      aria-activedescendant={selectedElement?.id}
+      onKeyDown={handleKeyDown}
+    >
+      <li id={ITEMS[0]} aria-disabled={true}>
+        {ITEMS[0]}
+      </li>
+      <li id={ITEMS[1]} hidden>
+        {ITEMS[1]}
+      </li>
+      <li id={ITEMS[2]}>{ITEMS[2]}</li>
+    </ul>
+  );
+}
+
+const ACTIVE_DESCENDANT_SELECTOR = 'aria-activedescendant';
+describe('hooks/useListNavigation — list only', () => {
+  test('ArrowDown 키입력이 있을 때 탐색 가능한 첫 번째 다음요소 반환', async () => {
+    const { container } = render(<BasicExample />);
+    const listElement = container.querySelector('ul');
+
+    fireEvent.focus(listElement!);
+    fireEvent.keyDown(listElement!, { key: 'ArrowDown' });
+
+    expect(listElement).toHaveAttribute(ACTIVE_DESCENDANT_SELECTOR, ITEMS[0]);
+  });
+
+  test('ArrowUp 키입력이 있을 때 탐색 가능한 첫 번째 이전요소 반환', () => {
+    const { container } = render(<BasicExample />);
+    const listElement = container.querySelector('ul');
+
+    fireEvent.focus(listElement!);
+    // ⬇️ ⬇️ ⬆️ === first item
+    fireEvent.keyDown(listElement!, { key: 'ArrowDown' });
+    fireEvent.keyDown(listElement!, { key: 'ArrowDown' });
+    fireEvent.keyDown(listElement!, { key: 'ArrowUp' });
+
+    expect(listElement).toHaveAttribute(ACTIVE_DESCENDANT_SELECTOR, ITEMS[0]);
+  });
+
+  test('키보드 탐색 시 유효하지 않은 아이템은 건너뛴다.', () => {
+    const { container } = render(<InvalidItemExample />);
+    const listElement = container.querySelector('ul');
+
+    fireEvent.focus(listElement!);
+    // ⬇️
+    fireEvent.keyDown(listElement!, { key: 'ArrowDown' });
+
+    expect(listElement).toHaveAttribute(ACTIVE_DESCENDANT_SELECTOR, ITEMS[2]);
+  });
+
+  test('전체 순회 옵션이 참일 경우 첫번째 아이템에서 이전 아이템 탐색 시 마지막 아이템 반환', () => {
+    const { container } = render(<BasicExample loop={true} />);
+    const listElement = container.querySelector('ul');
+
+    fireEvent.focus(listElement!);
+    // 0. noting
+    // 1. ⬇️ : first item selected
+    fireEvent.keyDown(listElement!, { key: 'ArrowDown' });
+    // 2. ⬆️ : last item selected
+    fireEvent.keyDown(listElement!, { key: 'ArrowUp' });
+
+    expect(listElement).toHaveAttribute(
+      ACTIVE_DESCENDANT_SELECTOR,
+      ITEMS[ITEMS.length - 1]
+    );
+  });
+});
+
+describe('hooks/useListNavigation — has other interactive element', () => {
+  test('<input />에 포커스된 상태에서도 키보드 탐색이 가능하다.', () => {
+    const { container } = render(<InputExample />);
+    const inputElement = container.querySelector('input');
+    const listElement = container.querySelector('ul');
+
+    fireEvent.focus(inputElement!);
+    // 1. ⬇️ : first item selected
+    fireEvent.keyDown(inputElement!, { key: 'ArrowDown' });
+
+    expect(listElement).toHaveAttribute(ACTIVE_DESCENDANT_SELECTOR, ITEMS[0]);
+  });
+});

--- a/src/hooks/useListNavigation.ts
+++ b/src/hooks/useListNavigation.ts
@@ -5,19 +5,10 @@ interface Params {
   listRef: RefObject<HTMLElement>;
   loop?: boolean;
 }
+
 export default function useListNavigation(params: Params) {
   const { itemSelector = '*', listRef, loop } = params;
   const [selectedElement, setSelectedElement] = useState<Element>();
-
-  function getSelectedItem() {
-    if (listRef.current == null) {
-      return;
-    }
-
-    return listRef.current.querySelector(
-      `${itemSelector}[aria-selected="true"]`
-    );
-  }
 
   function getValidItems() {
     if (listRef.current == null) {
@@ -32,7 +23,6 @@ export default function useListNavigation(params: Params) {
   }
 
   function updateSelected(orientation: 'end' | 'start') {
-    const selected = getSelectedItem();
     const validItems = getValidItems();
 
     if (validItems == null) {
@@ -40,7 +30,8 @@ export default function useListNavigation(params: Params) {
     }
 
     const indexOffset = orientation === 'end' ? 1 : -1;
-    const currentIndex = validItems.findIndex(item => item === selected) ?? -1;
+    const currentIndex =
+      validItems.findIndex(item => item === selectedElement) ?? -1;
     const nextIndex = indexOffset + currentIndex;
 
     if (loop) {
@@ -58,12 +49,11 @@ export default function useListNavigation(params: Params) {
     }
   }
 
-  // TODO: index받도록 리팩토링
-  function selectFirstItem() {
-    const item = getValidItems()?.find(item => !item.ariaDisabled);
-    // const value = item?.getAttribute(VALUE_ATTR);
-    // store.setState('value', value || undefined);
-    setSelectedElement(item);
+  function selectItem(fn: (el: Element) => boolean) {
+    const nextSelectedItem = getValidItems()?.find(fn);
+    if (nextSelectedItem != null) {
+      setSelectedElement(nextSelectedItem);
+    }
   }
 
   function handleKeyDown(e: KeyboardEvent) {
@@ -82,5 +72,5 @@ export default function useListNavigation(params: Params) {
     }
   }
 
-  return [selectedElement, { handleKeyDown, selectFirstItem }] as const;
+  return [selectedElement, { handleKeyDown, selectItem }] as const;
 }

--- a/src/hooks/useListNavigation.ts
+++ b/src/hooks/useListNavigation.ts
@@ -1,0 +1,86 @@
+import { RefObject, KeyboardEvent, useState } from 'react';
+
+interface Params {
+  itemSelector?: string;
+  listRef: RefObject<HTMLElement>;
+  loop?: boolean;
+}
+export default function useListNavigation(params: Params) {
+  const { itemSelector = '*', listRef, loop } = params;
+  const [selectedElement, setSelectedElement] = useState<Element>();
+
+  function getSelectedItem() {
+    if (listRef.current == null) {
+      return;
+    }
+
+    return listRef.current.querySelector(
+      `${itemSelector}[aria-selected="true"]`
+    );
+  }
+
+  function getValidItems() {
+    if (listRef.current == null) {
+      return;
+    }
+
+    return Array.from(
+      listRef.current.querySelectorAll(
+        `${itemSelector}:not([aria-disabled="true"]):not([disabled="true"]):not([hidden])`
+      )
+    );
+  }
+
+  function updateSelected(orientation: 'end' | 'start') {
+    const selected = getSelectedItem();
+    const validItems = getValidItems();
+
+    if (validItems == null) {
+      return;
+    }
+
+    const indexOffset = orientation === 'end' ? 1 : -1;
+    const currentIndex = validItems.findIndex(item => item === selected) ?? -1;
+    const nextIndex = indexOffset + currentIndex;
+
+    if (loop) {
+      nextIndex < 0
+        ? validItems.length - 1
+        : nextIndex === validItems.length
+        ? 0
+        : nextIndex;
+    }
+
+    const nextSelectedItem = validItems[nextIndex];
+    if (nextSelectedItem != null) {
+      setSelectedElement(nextSelectedItem);
+    }
+  }
+
+  // TODO: index받도록 리팩토링
+  function selectFirstItem() {
+    const item = getValidItems()?.find(item => !item.ariaDisabled);
+    // const value = item?.getAttribute(VALUE_ATTR);
+    // store.setState('value', value || undefined);
+    setSelectedElement(item);
+  }
+
+  function handleKeyDown(e: KeyboardEvent) {
+    if (e.defaultPrevented) {
+      return;
+    }
+
+    // TODO: extra key binding
+    switch (e.key) {
+      case 'ArrowDown': {
+        updateSelected('end');
+        break;
+      }
+      case 'ArrowUp': {
+        updateSelected('start');
+      }
+    }
+  }
+
+  return [selectedElement, { handleKeyDown, selectFirstItem }] as const;
+}

--- a/src/hooks/useListNavigation.ts
+++ b/src/hooks/useListNavigation.ts
@@ -32,14 +32,14 @@ export default function useListNavigation(params: Params) {
     const indexOffset = orientation === 'end' ? 1 : -1;
     const currentIndex =
       validItems.findIndex(item => item === selectedElement) ?? -1;
-    const nextIndex = indexOffset + currentIndex;
+    let nextIndex = indexOffset + currentIndex;
 
     if (loop) {
-      nextIndex < 0
-        ? validItems.length - 1
-        : nextIndex === validItems.length
-        ? 0
-        : nextIndex;
+      if (nextIndex < 0) {
+        nextIndex = validItems.length - 1;
+      }
+
+      nextIndex = nextIndex === validItems.length ? 0 : nextIndex;
     }
 
     const nextSelectedItem = validItems[nextIndex];

--- a/src/hooks/useListNavigation.ts
+++ b/src/hooks/useListNavigation.ts
@@ -54,6 +54,7 @@ export default function useListNavigation(params: Params) {
     const nextSelectedItem = validItems[nextIndex];
     if (nextSelectedItem != null) {
       setSelectedElement(nextSelectedItem);
+      return nextSelectedItem;
     }
   }
 
@@ -73,11 +74,10 @@ export default function useListNavigation(params: Params) {
     // TODO: extra key binding
     switch (e.key) {
       case 'ArrowDown': {
-        updateSelected('end');
-        break;
+        return updateSelected('end');
       }
       case 'ArrowUp': {
-        updateSelected('start');
+        return updateSelected('start');
       }
     }
   }

--- a/src/pages/tree-view.tsx
+++ b/src/pages/tree-view.tsx
@@ -1,0 +1,29 @@
+import Tree from '../components/content/tree-view/TreeView';
+import PageLayout from '../components/layout/PageLayout';
+
+export default function TreeView() {
+  return (
+    <PageLayout>
+      <PageLayout.Title>Tree View</PageLayout.Title>
+      <PageLayout.Details>muscle</PageLayout.Details>
+      <Tree>
+        <input />
+        <Tree.List>
+          <Tree.Item value="value1">
+            value1
+            <Tree.OpenControl>
+              {({ open }) => <button>{open ? '⬇️' : '➡️'}</button>}
+            </Tree.OpenControl>
+            <Tree.SubList>
+              <Tree.Item value="item1-1">item 1 - 1</Tree.Item>
+              <Tree.Item value="item1-2">item 1 - 2</Tree.Item>
+            </Tree.SubList>
+          </Tree.Item>
+          <Tree.Item value="value2">value2</Tree.Item>
+          <Tree.Item value="value3">value3</Tree.Item>
+          <Tree.Item value="value4">value4</Tree.Item>
+        </Tree.List>
+      </Tree>
+    </PageLayout>
+  );
+}


### PR DESCRIPTION
## useListNavigation

navigate elements with the keyboard without using `.focus()`
: can use `.focus()` to handle keyboard navigation, but since only one element in the element tree can have focus, it is difficult to handle keyboard navigation in [comboboxes](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) that handle search and keyboard navigation at the same time.